### PR TITLE
Implement websocket trigger for attendances

### DIFF
--- a/api/routes/attendances.py
+++ b/api/routes/attendances.py
@@ -1,4 +1,3 @@
-# api/routes/attendances.py
 from datetime import datetime
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -6,7 +5,10 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from core.db import get_db
+from core.websocket_manager import WebSocketManager
 from models.attendance import AttendanceStatus
+from models.student import Student
+from fastapi import WebSocket, WebSocketDisconnect
 from crud import attendance as attendance_crud
 
 class AttendanceBase(BaseModel):
@@ -83,12 +85,41 @@ def delete_attendance(attendance_id: int, db: Session = Depends(get_db)):
     attendance_crud.delete_attendance(db, attendance_id=attendance_id)
     return {"detail": "Attendance deleted successfully"}
 
+manager = WebSocketManager()
+
 @router.post("/check", status_code=status.HTTP_200_OK)
-def check_attendance(attendance: AttendanceCheck, db: Session = Depends(get_db)):
+async def check_attendance(attendance: AttendanceCheck, db: Session = Depends(get_db)):
     """ Creates the attendance object and checks attendance based on the student rfid id"""
     result = attendance_crud.check_attendance(
         db=db,
         rfid_card_id=attendance.rfid_card_id,
         room=attendance.room
     )
+
+    # Broadcast the attendance event to all connected WebSocket clients
+    if result not in ["Unknown card", "No active session", "Error processing attendance"]:
+        student = db.query(Student).filter(Student.rfid_card_id == attendance.rfid_card_id).first()
+        student_name = student.name if student else "Unknown"
+
+        notification = {
+            "type": "attendance",
+            "student": student_name,
+            "room": attendance.room,
+            "status": result,
+            "timestamp": datetime.utcnow().isoformat()
+        }
+        import json
+        await manager.broadcast(json.dumps(notification))
+
     return {"message": result}
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(f"Waiting for attendance: {data}")
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/core/websocket_manager.py
+++ b/core/websocket_manager.py
@@ -1,0 +1,21 @@
+from fastapi import WebSocket
+
+class WebSocketManager:
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: str):
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception:
+                self.disconnect(connection)
+                pass

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.cors_origins,
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sqlalchemy~=2.0
 bcrypt~=4.3
 pydantic[email]
 serial
+websockets

--- a/tests/manual/ws_test.py
+++ b/tests/manual/ws_test.py
@@ -1,0 +1,12 @@
+import asyncio
+import websockets
+
+async def listen(uri):
+    async with websockets.connect(uri) as websocket:
+        print(f"Connected to {uri}")
+        while True:
+            message = await websocket.recv()
+            print(f"Received message: {message}")
+
+uri = "ws://localhost:8000/api/attendances/ws"
+asyncio.run(listen(uri))


### PR DESCRIPTION
This thing solves issue #9 

Mainly, I've added a `ConnectionManager` (`WebSocketManager` in our case) that will orchestrate  websockets and work as a broadcast (send messages to client) -> https://fastapi.tiangolo.com/advanced/websockets/#handling-disconnections-and-multiple-clients 

The manager is connected to two endpoints (`attendance/check` and `attendance/ws`), and whilst the first one is connecting to the `manager` and broadcasting the message (via websockets), the second one is constantly opened (meaning the client should be connected to it).

I've done a manual test script that will basically connects to the ws endpoint and listens. Here is the demonstration of how it works with check attendance:
![image](https://github.com/user-attachments/assets/fcaa4fb3-bc41-4c42-afa3-8c6246f6c329)

Also the logs for the backend:
![image](https://github.com/user-attachments/assets/fc4d91a3-5a0c-47e4-a473-0dec8025b60e)


> Important: You should launch the script and the server paralelly. Also the websocket endpoint is: `ws://localhost:8000/api/attendances/ws`. Don't try to test it with Postman, bc it won't work (there is a bug with postman)
